### PR TITLE
Run NPM commands as non root user

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -59,3 +59,7 @@ setup_resource() {
     setup_npmrc
     setup_package
 }
+
+npm() {
+    su node -c "npm $*"
+}

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -9,14 +9,14 @@ scope=""
 yarn_args=""
 
 setup_npmrc() {
-    echo -n > $HOME/.npmrc
+    echo -n > /home/node/.npmrc
     
     if [ -n "$token" ]; then
         token_target="${registry:-https://registry.npmjs.org/}"
         token_target="${token_target/http*:/}"
         
         echo "${token_target}:_authToken=$token" \
-        >> $HOME/.npmrc
+        >> /home/node/.npmrc
 
         echo "  Using token for authentication"
     fi
@@ -28,7 +28,7 @@ setup_npmrc() {
         fi
 
         echo "@${scope}:registry=${registry}" \
-        >> $HOME/.npmrc
+        >> /home/node/.npmrc
 
         echo "  Scope limited to @$scope"
     fi

--- a/assets/in
+++ b/assets/in
@@ -25,7 +25,7 @@ skip_download=$(jq -r '.params.skip_download // ""' < $payload)
 setup_resource
 echo "Resource setup successful."
 
-cd "$1"
+cd "$1" && chown -R node:node .
 
 [ -n "$scope" ] \
 && fqpn="@$scope/$package" \

--- a/assets/out
+++ b/assets/out
@@ -37,7 +37,7 @@ fi
 setup_resource
 echo "Resource setup successful."
 
-cd "$1/$package_path"
+cd "$1/$package_path" && chown -R node:node .
 
 manifestName="$(jq -r .name < package.json)"
 


### PR DESCRIPTION
Change makes `npm` CLI commands run as non root user.

Running `npm` CLI commands such as `npm publish` as a root user makes package scripts fail. It means that if NPM package uses `prepublishOnly` script to for example transpire TS files into JS such script won't run properly resulting in an empty package being published.

Below is example error from the CI server:

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/1724691/95611732-26d8aa00-0a5a-11eb-8f75-3d297753b332.png">

Alternative solution could use of `unsafe-perm` flag (https://docs.npmjs.com/using-npm/config#unsafe-perm) to disable user downgrade when scripts are run but this is not a safe / recommended solution.