### PR TITLE
Fix permissions issue when running as user `node`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM node:alpine
 
 RUN apk --update --no-cache add bash jq
 
-ADD assets /opt/resource
+USER node:node
+ADD --chown=node:node assets /opt/resource

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -9,14 +9,14 @@ scope=""
 yarn_args=""
 
 setup_npmrc() {
-    echo -n > /home/node/.npmrc
+    echo -n > $HOME/.npmrc
     
     if [ -n "$token" ]; then
         token_target="${registry:-https://registry.npmjs.org/}"
         token_target="${token_target/http*:/}"
         
         echo "${token_target}:_authToken=$token" \
-        >> /home/node/.npmrc
+        >> $HOME/.npmrc
 
         echo "  Using token for authentication"
     fi
@@ -28,7 +28,7 @@ setup_npmrc() {
         fi
 
         echo "@${scope}:registry=${registry}" \
-        >> /home/node/.npmrc
+        >> $HOME/.npmrc
 
         echo "  Scope limited to @$scope"
     fi
@@ -58,8 +58,4 @@ setup_resource() {
     echo "Initializing npmrc..."
     setup_npmrc
     setup_package
-}
-
-npm() {
-    su node -c "npm $*"
 }

--- a/assets/in
+++ b/assets/in
@@ -25,7 +25,7 @@ skip_download=$(jq -r '.params.skip_download // ""' < $payload)
 setup_resource
 echo "Resource setup successful."
 
-cd "$1" && chown -R node:node .
+cd "$1"
 
 [ -n "$scope" ] \
 && fqpn="@$scope/$package" \

--- a/assets/out
+++ b/assets/out
@@ -37,7 +37,7 @@ fi
 setup_resource
 echo "Resource setup successful."
 
-cd "$1/$package_path" && chown -R node:node .
+cd "$1/$package_path"
 
 manifestName="$(jq -r .name < package.json)"
 


### PR DESCRIPTION
Undo changes made to scripts for running on behalf of user `node` and specify the `USER` in Dockerfile instead.

Closes https://github.com/timotto/concourse-npm-resource/issues/5.