### PR TITLE
added new optional parameter to out resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Publishes the given NPM package to a private or public registry.
 
 * `path`: *Required.* Path to the directory containing the `package.json` file.
 * `version`: *Optional.* Path to a file containing the version, overrides the version stored in `package.json`.
+* `public`: *Optional.* Boolean to publish npm package with args `--access public`. Default=false.
 
 ## Example
 

--- a/assets/out
+++ b/assets/out
@@ -46,13 +46,20 @@ if [ ! "@$scope/$package" = "$manifestName" ] && [ ! "$package" = "$manifestName
   exit 1
 fi
 
-# optional version override though "params: {version: path/to/version/file}"
+# optional version override through "params: {version: path/to/version/file}"
 [ -n "$version_string" ] \
 && npm version "$version_string" \
 || version_string=$(jq -r .version < package.json)
 
+args=""
+# optional publish package with '--access public' through "params: {public: true}"
+public=$(jq -r '.params.public' < $payload)
+if [ "$public" = true ]; then
+  args=" --access public"
+fi
+
 echo "Publishing..."
-npm publish \
+npm publish $args \
 > $publish_result_file \
 2> $publish_result_file \
 && publish_result_code=$? \


### PR DESCRIPTION
added new optional parameter to out resource in order to publish with args "--access public". this is required in order to publish a public scoped package to npm.